### PR TITLE
remove the obsolete TODO comments within pipeline.py 

### DIFF
--- a/cflearn/pipeline.py
+++ b/cflearn/pipeline.py
@@ -256,7 +256,6 @@ class Pipeline(LoggingMixinWithRank):
                 self.tr_data, self.cv_data = split.remained, split.split
                 self.tr_split_indices = split.remained_indices
                 self.cv_split_indices = split.split_indices
-                # TODO : utilize cv_weights with sample_weights[split.split_indices]
                 if sample_weights is not None:
                     self.tr_weights = sample_weights[split.remained_indices]
                     self.cv_weights = sample_weights[split.split_indices]


### PR DESCRIPTION
The pending task of the TODO comment has already been resolved in the earlier version (https://github.com/carefree0910/carefree-learn/commit/dc6fb7b141ca7e0efee5b5714d5c10bf845c18c6).
